### PR TITLE
Fix iterator crash from name-mangled methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,11 @@ jobs:
         # FIXME: python -m pip won't work in CI
         # pip install .
 
-    # - name: Test
-    #   run: |
-    #     pip install pytest
-    #     pytest tests
+    - name: Test
+      run: |
+        pip install pytest
+        # setup.py install leaves octomap's dependent .so files in _skbuild;
+        # put them on the loader path so `import octomap` resolves them.
+        export LD_LIBRARY_PATH="$(find "$PWD/_skbuild" -name 'libdynamicedt3d.so*' -exec dirname {} \; | head -n1):$LD_LIBRARY_PATH"
+        cd tests
+        pytest .

--- a/octomap/octomap.pyx
+++ b/octomap/octomap.pyx
@@ -114,12 +114,12 @@ cdef class iterator_base:
         if self.thisptr:
             del self.thisptr
 
-    def __is_end(self):
+    def _is_end(self):
         return deref(self.thisptr) == self.treeptr.end_tree()
 
-    def __is_acceseable(self):
+    def _is_acceseable(self):
         if self.thisptr and self.treeptr:
-            if not self.__is_end():
+            if not self._is_end():
                 return True
         return False
 
@@ -128,14 +128,14 @@ cdef class iterator_base:
         return the center coordinate of the current node
         """
         cdef defs.Vector3 pt
-        if self.__is_acceseable():
+        if self._is_acceseable():
             pt = self.thisptr.getCoordinate()
             return np.array((pt.x(), pt.y(), pt.z()))
         else:
             raise NullPointerException
 
     def getDepth(self):
-        if self.__is_acceseable():
+        if self._is_acceseable():
             return self.thisptr.getDepth()
         else:
             raise NullPointerException
@@ -144,7 +144,7 @@ cdef class iterator_base:
         """
         the OcTreeKey of the current node
         """
-        if self.__is_acceseable():
+        if self._is_acceseable():
             key = OcTreeKey()
             key.thisptr[0][0] = self.thisptr.getKey()[0]
             key.thisptr[0][1] = self.thisptr.getKey()[1]
@@ -157,7 +157,7 @@ cdef class iterator_base:
         """
         the OcTreeKey of the current node, for nodes with depth != maxDepth
         """
-        if self.__is_acceseable():
+        if self._is_acceseable():
             key = OcTreeKey()
             key.thisptr[0][0] = self.thisptr.getIndexKey()[0]
             key.thisptr[0][1] = self.thisptr.getIndexKey()[1]
@@ -167,35 +167,35 @@ cdef class iterator_base:
             raise NullPointerException
 
     def getSize(self):
-        if self.__is_acceseable():
+        if self._is_acceseable():
             return self.thisptr.getSize()
         else:
             raise NullPointerException
 
     def getX(self):
-        if self.__is_acceseable():
+        if self._is_acceseable():
             return self.thisptr.getX()
         else:
             raise NullPointerException
     def getY(self):
-        if self.__is_acceseable():
+        if self._is_acceseable():
             return self.thisptr.getY()
         else:
             raise NullPointerException
     def getZ(self):
-        if self.__is_acceseable():
+        if self._is_acceseable():
             return self.thisptr.getZ()
         else:
             raise NullPointerException
 
     def getOccupancy(self):
-        if self.__is_acceseable():
+        if self._is_acceseable():
             return (<defs.OcTreeNode>deref(deref(self.thisptr))).getOccupancy()
         else:
             raise NullPointerException
 
     def getValue(self):
-        if self.__is_acceseable():
+        if self._is_acceseable():
             return (<defs.OcTreeNode>deref(deref(self.thisptr))).getValue()
         else:
             raise NullPointerException
@@ -210,7 +210,7 @@ cdef class tree_iterator(iterator_base):
 
     def next(self):
         if self.thisptr and self.treeptr:
-            if not self.__is_end():
+            if not self._is_end():
                 inc(deref(defs.static_cast[tree_iterator_ptr](self.thisptr)))
                 return self
             else:
@@ -220,7 +220,7 @@ cdef class tree_iterator(iterator_base):
 
     def __iter__(self):
         if self.thisptr and self.treeptr:
-            while not self.__is_end():
+            while not self._is_end():
                 yield self
                 if self.thisptr:
                     inc(deref(defs.static_cast[tree_iterator_ptr](self.thisptr)))
@@ -230,7 +230,7 @@ cdef class tree_iterator(iterator_base):
             raise NullPointerException
 
     def isLeaf(self):
-        if self.__is_acceseable():
+        if self._is_acceseable():
             return defs.static_cast[tree_iterator_ptr](self.thisptr).isLeaf()
         else:
             raise NullPointerException
@@ -244,7 +244,7 @@ cdef class leaf_iterator(iterator_base):
 
     def next(self):
         if self.thisptr and self.treeptr:
-            if not self.__is_end():
+            if not self._is_end():
                 inc(deref(defs.static_cast[leaf_iterator_ptr](self.thisptr)))
                 return self
             else:
@@ -254,7 +254,7 @@ cdef class leaf_iterator(iterator_base):
 
     def __iter__(self):
         if self.thisptr and self.treeptr:
-            while not self.__is_end():
+            while not self._is_end():
                 yield self
                 if self.thisptr:
                     inc(deref(defs.static_cast[leaf_iterator_ptr](self.thisptr)))
@@ -272,7 +272,7 @@ cdef class leaf_bbx_iterator(iterator_base):
 
     def next(self):
         if self.thisptr and self.treeptr:
-            if not self.__is_end():
+            if not self._is_end():
                 inc(deref(defs.static_cast[leaf_bbx_iterator_ptr](self.thisptr)))
                 return self
             else:
@@ -282,7 +282,7 @@ cdef class leaf_bbx_iterator(iterator_base):
 
     def __iter__(self):
         if self.thisptr and self.treeptr:
-            while not self.__is_end():
+            while not self._is_end():
                 yield self
                 if self.thisptr:
                     inc(deref(defs.static_cast[leaf_bbx_iterator_ptr](self.thisptr)))

--- a/tests/octomap_test.py
+++ b/tests/octomap_test.py
@@ -200,6 +200,33 @@ class OctreeTestCase(unittest.TestCase):
             lambda: self.tree.isNodeOccupied(node3),
         )
 
+    def test_dynamicEDT(self):
+        # A single occupied voxel at the origin: the Euclidean distance
+        # transform should read ~0 at the obstacle and grow linearly with
+        # distance away from it.
+        self.tree.updateNode(np.array([0.0, 0.0, 0.0]), True)
+        self.tree.updateInnerOccupancy()
+        self.tree.dynamicEDT_generate(
+            maxdist=4.0,
+            bbx_min=np.array([-2.0, -2.0, -2.0]),
+            bbx_max=np.array([2.0, 2.0, 2.0]),
+            treatUnknownAsOccupied=False,
+        )
+        self.tree.dynamicEDT_update(True)
+
+        res = self.tree.getResolution()
+        self.assertAlmostEqual(
+            self.tree.dynamicEDT_getDistance(np.array([0.0, 0.0, 0.0])),
+            0.0,
+            delta=res,
+        )
+        self.assertAlmostEqual(
+            self.tree.dynamicEDT_getDistance(np.array([1.0, 0.0, 0.0])),
+            1.0,
+            delta=res,
+        )
+        self.assertGreaterEqual(self.tree.dynamicEDT_getMaxDist(), 4.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

  1. Fix an iterator crash from name-mangled private helpers. `__is_end` and `__is_acceseable` are defined on `iterator_base` but called from the subclasses `tree_iterator`, `leaf_iterator`, `leaf_bbx_iterator` via `self.__is_end()`. Python name-mangling rewrites the call inside a subclass to `_<subclass>__is_end`, which doesn't exist (the method mangles to `_iterator_base__is_end` at its definition). Iterating then raises: 

         AttributeError: 'octomap.leaf_iterator' object has no attribute '_leaf_iterator__is_end'

and `tree_iterator.isLeaf()` fails the same way via `__is_acceseable`.  Renaming both to single-underscore (`_is_end`, `_is_acceseable`) avoids mangling so subclasses resolve them correctly.

Note: this appears to be Cython-version sensitive — name-mangling of `__methods` in `cdef class` differs across Cython releases, so a wheel built with a newer Cython exposes the crash even though the existing `test_Iterator` passed on an older build.

2. Add a test for the dynamicEDT3D distance field, which previously had no coverage: a single-voxel obstacle, asserting the distance reads ~0 at the obstacle and ~1 m one metre away. Not that big of a test, but def a smoke gun worth having. 
