### PR TITLE
ci: pin octomap build to C++14 to fix compile on modern compilers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,9 @@ def main():
         ext_modules=ext_modules,
         cmdclass={"build_ext": build_ext},
         cmake_source_dir="src/octomap",
+        # OctoMap 1.8.0 predates C++17; on newer compilers (e.g. GCC 13) the
+        # default gnu++17 makes octomap's `byte` typedef clash with std::byte.
+        cmake_args=["-DCMAKE_CXX_STANDARD=14"],
     )
 
 


### PR DESCRIPTION
CI fails on the GitHub runner because GCC 13 defaults to `-std=gnu++17`, and OctoMap 1.8.0 predates C++17. In `binvox2bt.cpp`, `using namespace std` plus a local `typedef unsigned char byte` collides with `std::byte`, so the build aborts with `reference to 'byte' is ambiguous`. Pinning the octomap CMake build to C++14 (where `std::byte` does not exist) resolves it. octomap was written for C++03/11, so C++14 is safe.

Verified the root cause directly: `clang++ -std=c++17 src/binvox2bt.cpp` reproduces the exact error; `-std=c++14` compiles clean.

## Test plan
- [x] CI build passes on GCC 13 (the authoritative check; cannot reproduce locally since macOS clang does not default to the offending standard)
