### PR TITLE
chore: add LICENSE, drop Py2/3.5, bump CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
         python-version: [3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -33,7 +33,6 @@ jobs:
       run: |
         pip install black
         black --check .
-      if: matrix.python-version != '2.7' && matrix.python-version != '3.5'
 
     - name: Install from source
       run: |

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2013-2026, Kentaro Wada
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ def main():
         extras_require={
             "example": ["glooey", "imgviz>=1.2.0", "pyglet", "trimesh[easy]"],
         },
-        license="BSD",
+        license="BSD-3-Clause",
         maintainer="Kentaro Wada",
         maintainer_email="www.kentaro.wada@gmail.com",
         url="https://github.com/wkentaro/octomap-python",
@@ -95,9 +95,9 @@ def main():
         classifiers=[
             "Development Status :: 5 - Production/Stable",
             "Intended Audience :: Developers",
+            "License :: OSI Approved :: BSD License",
             "Natural Language :: English",
             "Programming Language :: Python",
-            "Programming Language :: Python :: 2",
             "Programming Language :: Python :: 3",
             "Programming Language :: Python :: Implementation :: CPython",
             "Programming Language :: Python :: Implementation :: PyPy",


### PR DESCRIPTION
Low-risk hygiene pass with no build-logic changes.

- Add a top-level BSD 3-Clause `LICENSE` (the project declared BSD but shipped no license file); `setup.py` now declares the SPDX id `license="BSD-3-Clause"` and carries the matching `License :: OSI Approved :: BSD License` trove classifier.
- Drop dead Python 2 / 3.5 references: the `Programming Language :: Python :: 2` classifier and the `python-version != '2.7' / '3.5'` guard on the CI `black` step (the matrix is 3.9-only).
- Bump `actions/checkout@v2 -> v4` and `actions/setup-python@v2 -> v5`.

## Test plan
- [x] `flake8 .` and `black --check .` pass (the same checks CI runs)
- [x] `setup.py` parses (`python -m py_compile setup.py`)

Closes #26
