### PR TITLE
fix: populate castRay end coordinate regardless of hit

### DIFF
--- a/octomap/octomap.pyx
+++ b/octomap/octomap.pyx
@@ -404,8 +404,16 @@ cdef class OcTree:
         the first occupied cell is returned (as center coordinate).
         If the starting coordinate is already occupied in the tree,
         this coordinate will be returned as a hit.
+
+        `end` receives the center of the voxel where the ray stopped,
+        whether or not an occupied cell was hit, so a miss (return False)
+        still reports the stopping point. If the ray cannot be cast at all
+        (origin outside the tree, or a zero direction), `end` is left
+        unchanged.
         """
-        cdef defs.point3d e
+        # seed e from end so that, like the C++ point3d& reference, end is
+        # preserved on the early-exit paths where castRay never writes it
+        cdef defs.point3d e = defs.point3d(end[0], end[1], end[2])
         cdef cppbool hit
         hit = self.thisptr.castRay(
             defs.point3d(origin[0], origin[1], origin[2]),
@@ -414,8 +422,7 @@ cdef class OcTree:
             bool(ignoreUnknownCells),
             <double?>maxRange
         )
-        if hit:
-            end[0:3] = e.x(), e.y(), e.z()
+        end[0:3] = e.x(), e.y(), e.z()
         return hit
 
     read = _octree_read

--- a/tests/octomap_test.py
+++ b/tests/octomap_test.py
@@ -114,15 +114,18 @@ class OctreeTestCase(unittest.TestCase):
         direction = np.array([1.0, 0.0, 0.0])
         end = np.array([0.0, 0.0, 0.0])
 
-        # miss
+        # miss still reports where the ray stopped: the voxel entered when
+        # the ray reached maxRange=5.0 along x, with y/z at the origin voxel
+        # center (0.05 = half of the 0.1 resolution)
         hit = self.tree.castRay(
             origin=origin,
             direction=direction,
             end=end,
             ignoreUnknownCells=True,
+            maxRange=5.0,
         )
         self.assertFalse(hit)
-        self.assertTrue(np.all(end == 0.0))
+        self.assertTrue(np.allclose(end, [5.05, 0.05, 0.05]))
 
         self.tree.insertPointCloud(
             np.array(
@@ -137,6 +140,7 @@ class OctreeTestCase(unittest.TestCase):
         )
 
         # hit
+        end[:] = [9.0, 9.0, 9.0]
         hit = self.tree.castRay(
             origin=origin,
             direction=direction,
@@ -145,6 +149,19 @@ class OctreeTestCase(unittest.TestCase):
         )
         self.assertTrue(hit)
         self.assertTrue(np.allclose(end, [1.05, 0.05, 0.05]))
+
+        # a ray that cannot be cast (origin outside the tree) leaves end
+        # unchanged rather than overwriting it
+        end[:] = [7.0, 7.0, 7.0]
+        hit = self.tree.castRay(
+            origin=np.array([1e6, 1e6, 1e6]),
+            direction=direction,
+            end=end,
+            ignoreUnknownCells=True,
+            maxRange=5.0,
+        )
+        self.assertFalse(hit)
+        self.assertTrue(np.allclose(end, [7.0, 7.0, 7.0]))
 
     def test_updateNodes(self):
         # test points


### PR DESCRIPTION
`OcTree.castRay` only copied the computed endpoint into the caller's `end` array when the ray hit an occupied cell, so on a miss the caller could not recover where the ray stopped. Per the OctoMap C++ API, `end` is meaningful regardless of the boolean return: the return distinguishes hit from miss, while `end` reports the last voxel the ray reached.

This removes the `if hit:` guard so `end` is always written. To stay faithful to the C++ `point3d& end` reference semantics, the local `point3d` is seeded from the caller's current `end`: on the early-exit paths where C++ never writes the endpoint (origin outside the tree, or a zero direction) `end` is then left unchanged, rather than being clobbered with `(0, 0, 0)`.

The docstring now documents the `end`-on-miss contract, and `test_castRay` covers the miss (end populated), hit, and cannot-cast (end unchanged) cases.

## Test plan
- [x] `pytest tests/` — 14 passed (built the extension locally and ran the suite)
- [x] Manually exercised `castRay` on hit / normal-miss / out-of-bounds-origin / zero-direction paths and confirmed `end` matches the documented contract

Closes #4
