### PR TITLE
feat: bind dynamicEDT getDistanceAndClosestObstacle

### DIFF
--- a/octomap/dynamicEDT3D_defs.pxd
+++ b/octomap/dynamicEDT3D_defs.pxd
@@ -4,6 +4,9 @@ cdef extern from "octomap/math/Vector3.h" namespace "octomath":
     cdef cppclass Vector3:
         Vector3() except +
         Vector3(float, float, float) except +
+        float& x()
+        float& y()
+        float& z()
 
 cdef extern from "octomap/octomap_types.h" namespace "octomap":
     ctypedef Vector3 point3d
@@ -22,5 +25,6 @@ cdef extern from "dynamicEDT3D/dynamicEDTOctomap.h":
         bool checkConsistency()
         float getDistance(point3d& p)
         float getDistance(OcTreeKey& k)
+        void getDistanceAndClosestObstacle(point3d& p, float& distance, point3d& closestObstacle)
         float getMaxDist()
         void update(bool updateRealDist)

--- a/octomap/octomap.pyx
+++ b/octomap/octomap.pyx
@@ -1,6 +1,7 @@
 from libcpp.string cimport string
 from libcpp cimport bool as cppbool
 from libc.string cimport memcpy
+from libc.math cimport NAN, isnan
 from cython.operator cimport dereference as deref, preincrement as inc, address
 cimport octomap_defs as defs
 cimport dynamicEDT3D_defs as edt
@@ -915,5 +916,25 @@ cdef class OcTree:
                 return self.edtptr.getDistance(edt.point3d(<float?>p[0],
                                                            <float?>p[1],
                                                            <float?>p[2]))
+        else:
+            raise NullPointerException
+
+    def dynamicEDT_getDistanceAndClosestObstacle(self, p):
+        """
+        Return (distance, closest_obstacle_xyz) for the query point p. The
+        closest obstacle is None when the library reports none: when p is
+        outside the distance map (distance -1.0) or no obstacle lies within
+        the maximum distance.
+        """
+        cdef float distance
+        cdef edt.point3d obstacle = edt.point3d(NAN, NAN, NAN)
+        if self.edtptr:
+            self.edtptr.getDistanceAndClosestObstacle(
+                edt.point3d(<float?>p[0], <float?>p[1], <float?>p[2]),
+                distance,
+                obstacle)
+            if isnan(obstacle.x()):
+                return distance, None
+            return distance, np.array((obstacle.x(), obstacle.y(), obstacle.z()))
         else:
             raise NullPointerException

--- a/tests/octomap_test.py
+++ b/tests/octomap_test.py
@@ -227,6 +227,44 @@ class OctreeTestCase(unittest.TestCase):
         )
         self.assertGreaterEqual(self.tree.dynamicEDT_getMaxDist(), 4.0)
 
+        # the only obstacle is the voxel at the origin, so the closest
+        # obstacle to any query point is ~[0, 0, 0], and the returned
+        # distance matches dynamicEDT_getDistance for the same query
+        query = np.array([1.0, 0.0, 0.0])
+        distance, obstacle = (
+            self.tree.dynamicEDT_getDistanceAndClosestObstacle(query)
+        )
+        self.assertEqual(distance, self.tree.dynamicEDT_getDistance(query))
+        self.assertTrue(np.allclose(obstacle, [0.0, 0.0, 0.0], atol=res))
+
+        # a query outside the distance map reports -1.0 and no obstacle
+        distance, obstacle = (
+            self.tree.dynamicEDT_getDistanceAndClosestObstacle(
+                np.array([10.0, 10.0, 10.0])
+            )
+        )
+        self.assertEqual(distance, -1.0)
+        self.assertIsNone(obstacle)
+
+        # a query inside the map but beyond maxdist has its distance capped
+        # at the maximum and no recorded obstacle (fresh tree to keep this
+        # tree's distance field intact)
+        far_tree = octomap.OcTree(0.1)
+        far_tree.updateNode(np.array([0.0, 0.0, 0.0]), True)
+        far_tree.updateInnerOccupancy()
+        far_tree.dynamicEDT_generate(
+            maxdist=1.0,
+            bbx_min=np.array([-3.0, -3.0, -3.0]),
+            bbx_max=np.array([3.0, 3.0, 3.0]),
+            treatUnknownAsOccupied=False,
+        )
+        far_tree.dynamicEDT_update(True)
+        distance, obstacle = far_tree.dynamicEDT_getDistanceAndClosestObstacle(
+            np.array([2.0, 0.0, 0.0])
+        )
+        self.assertEqual(distance, far_tree.dynamicEDT_getMaxDist())
+        self.assertIsNone(obstacle)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Exposes `DynamicEDTOctomap::getDistanceAndClosestObstacle` so callers can get the nearest obstacle's coordinate, not just the distance (the existing `dynamicEDT_getDistance` only returns the scalar).

`OcTree.dynamicEDT_getDistanceAndClosestObstacle(p)` returns `(distance, closest_obstacle_xyz)`. The C++ library leaves `closestObstacle` unwritten when there is no valid nearest obstacle: when the query is outside the distance map (distance is the `-1.0` sentinel) or no obstacle lies within the maximum distance (distance is capped at `getMaxDist()`). To detect this faithfully rather than guessing from the distance value, the local `point3d` is seeded with `NaN` and the result is treated as `None` when the library left it unset.

## Test plan
- [x] `pytest tests/` — 14 passed (built the extension locally and ran the suite)
- [x] Verified the three return paths by hand: in-map query returns the origin voxel; out-of-bounds returns `(-1.0, None)`; an in-map query beyond `maxdist` returns `(maxdist, None)`

## Note (out of scope)
While testing I noticed `dynamicEDT_generate` leaks the previous `DynamicEDTOctomap` when called more than once on the same tree (it `new`s without freeing the prior pointer; only `__dealloc__` frees it). I kept this PR scoped to the new binding and sidestepped the leak in the test by using a separate tree; the fix would mirror `__dealloc__` (`if self.edtptr: del self.edtptr` before the `new`). Worth a follow-up.

Closes #6
