### PR TITLE
fix: accept str paths for OcTree read/write, not only bytes

### DIFF
--- a/octomap/octomap.pyx
+++ b/octomap/octomap.pyx
@@ -4,6 +4,7 @@ from libc.string cimport memcpy
 from cython.operator cimport dereference as deref, preincrement as inc, address
 cimport octomap_defs as defs
 cimport dynamicEDT3D_defs as edt
+import os
 import numpy as np
 cimport numpy as np
 ctypedef np.float64_t DOUBLE_t
@@ -298,6 +299,7 @@ def _octree_read(filename):
     """
     cdef defs.istringstream iss
     cdef OcTree tree = OcTree(0.1)
+    filename = os.fsencode(filename)
     if filename.startswith(b"# Octomap OcTree file"):
         iss.str(string(<char*?>filename, len(filename)))
         del tree.thisptr
@@ -319,6 +321,7 @@ cdef class OcTree:
         if isinstance(arg, numbers.Number):
             self.thisptr = new defs.OcTree(<double?>arg)
         else:
+            arg = os.fsencode(arg)
             self.thisptr = new defs.OcTree(string(<char*?>arg))
 
     def __dealloc__(self):
@@ -426,6 +429,7 @@ cdef class OcTree:
         """
         cdef defs.ostringstream oss
         if not filename is None:
+            filename = os.fsencode(filename)
             return self.thisptr.write(string(<char*?>filename))
         else:
             ret = self.thisptr.write(<defs.ostream&?>oss)
@@ -436,6 +440,7 @@ cdef class OcTree:
 
     def readBinary(self, filename):
         cdef defs.istringstream iss
+        filename = os.fsencode(filename)
         if filename.startswith(b"# Octomap OcTree binary file"):
             iss.str(string(<char*?>filename, len(filename)))
             return self.thisptr.readBinary(<defs.istream&?>iss)
@@ -445,6 +450,7 @@ cdef class OcTree:
     def writeBinary(self, filename=None):
         cdef defs.ostringstream oss
         if not filename is None:
+            filename = os.fsencode(filename)
             return self.thisptr.writeBinary(string(<char*?>filename))
         else:
             ret = self.thisptr.writeBinary(<defs.ostream&?>oss)

--- a/tests/octomap_test.py
+++ b/tests/octomap_test.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 import unittest
 
 import numpy as np
@@ -18,6 +20,30 @@ class OctreeTestCase(unittest.TestCase):
 
     def test_writeBinary(self):
         self.assertTrue(self.tree.writeBinary(b"test1.bt"))
+
+    def test_str_paths(self):
+        self.tree.updateNode(np.array([1.0, 2.0, 3.0]), True)
+        self.tree.updateInnerOccupancy()
+        with tempfile.TemporaryDirectory() as tmp:
+            bt_path = os.path.join(tmp, "tree.bt")
+            ot_path = os.path.join(tmp, "tree.ot")
+
+            # writeBinary / readBinary round-trip with str paths
+            self.assertTrue(self.tree.writeBinary(bt_path))
+            expected_bt = self.tree.writeBinary()
+            tree_bin = octomap.OcTree(0.1)
+            self.assertTrue(tree_bin.readBinary(bt_path))
+            self.assertEqual(tree_bin.writeBinary(), expected_bt)
+
+            # the str constructor reads a .bt file without TypeError
+            tree_ctor = octomap.OcTree(bt_path)
+            self.assertEqual(tree_ctor.writeBinary(), expected_bt)
+
+            # write / read round-trip with str paths
+            self.assertTrue(self.tree.write(ot_path))
+            expected_ot = self.tree.write()
+            tree_full = octomap.OcTree.read(ot_path)
+            self.assertEqual(tree_full.write(), expected_ot)
 
     def test_checkTree(self):
         self.tree.readBinary(b"test.bt")


### PR DESCRIPTION
The `OcTree` constructor and the `read` / `readBinary` / `write` / `writeBinary` methods only accepted `bytes`, so a plain `str` path raised `TypeError` (the constructor cast straight to `char*`; `read`/`readBinary` sniffed the header with a `bytes`-literal `.startswith(...)`). Users had to `.encode()` manually (the documented workaround).

Each path/data argument is now normalized with the stdlib `os.fsencode(...)` before reaching the C++ layer and the header sniff. `os.fsencode` encodes `str` with the filesystem encoding, passes `bytes` through unchanged (so the existing raw-serialized-data branch of `read`/`readBinary` and all current callers are unaffected), and raises a clear `TypeError` on genuinely wrong types. As a side effect it also accepts `os.PathLike` (e.g. `pathlib.Path`); the brief scoped explicit `Path` support as a follow-up, so this PR does not add `Path` tests, but it now works.

## Test plan
- [x] `pytest tests/` — 15 passed (built the extension locally and ran the suite)
- [x] New `test_str_paths`: `str`-path `writeBinary`/`readBinary` round-trip, the `str` constructor reading a `.bt`, and a `write`/`read` `.ot` round-trip
- [x] Confirmed `bytes` paths still work (existing `test_checkBinary`/`test_checkTree` exercise the raw-`bytes` branches) and verified `bytes`/`str`/`pathlib.Path` constructors round-trip identically by hand

Closes #10
