### PR TITLE
feat: fetch OctoMap via CMake FetchContent and drop the submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,3 @@
 /test/test1.bt
 
 /*.so
-
-/src/
-!/src/octomap

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "src/octomap"]
-	path = src/octomap
-	url = https://github.com/OctoMap/octomap.git
-	version = v1.8.0
 [submodule "github2pypi"]
 	path = github2pypi
 	url = https://github.com/wkentaro/github2pypi.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,22 +2,50 @@
 cmake_minimum_required(VERSION 3.18)
 project(octomap_python LANGUAGES CXX)
 
-# OctoMap 1.8.0 predates C++17; on newer compilers the default gnu++17 makes
-# octomap's `byte` typedef clash with std::byte.
+# OctoMap targets an older C++ dialect; pin C++14 so its sources compile
+# cleanly (newer default standards make octomap's `byte` typedef clash with
+# std::byte).
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(
   Python REQUIRED COMPONENTS Interpreter Development.Module NumPy)
 
-set(octomap_dir "${CMAKE_CURRENT_SOURCE_DIR}/src/octomap")
+include(FetchContent)
+
+# OctoMap is fetched and pinned to a release tag rather than vendored as a git
+# submodule. Bumping the version is a one-line change to GIT_TAG.
+#
+# Pinned to v1.8.0 to match the package version line (octomap-python 1.8.0.postN
+# bundles octomap 1.8.0).
+FetchContent_Declare(
+  octomap
+  GIT_REPOSITORY https://github.com/OctoMap/octomap.git
+  GIT_TAG v1.8.0
+  GIT_SHALLOW TRUE
+)
+# Populate the sources only; octomap's own CMake build is intentionally not run.
+# FetchContent_MakeAvailable() would add_subdirectory(octomap), which both
+# defines a CMake target named `octomap` (colliding with python_add_library
+# below) and pulls in octovis/Qt. Source-only population needs the low-level
+# FetchContent_Populate(), which CMake 3.30 deprecated; CMP0169 keeps that path
+# available (the POLICY guard leaves older CMake, which lacks it, untouched).
+if(POLICY CMP0169)
+  cmake_policy(SET CMP0169 OLD)
+endif()
+FetchContent_GetProperties(octomap)
+if(NOT octomap_POPULATED)
+  FetchContent_Populate(octomap)
+endif()
+
+set(octomap_dir "${octomap_SOURCE_DIR}")
 set(octomap_src "${octomap_dir}/octomap/src")
 set(edt_src "${octomap_dir}/dynamicEDT3D/src")
 
 # OctoMap, octomath and dynamicEDT3D are compiled straight into the extension
 # so the module is self-contained: no octomap shared libraries to resolve at
 # import time. octovis/Qt are simply never referenced here. The source lists
-# mirror octomap's own CMakeLists for the pinned v1.8.0 submodule.
+# mirror octomap's own CMakeLists for the pinned release.
 set(octomap_sources
   ${octomap_src}/AbstractOcTree.cpp
   ${octomap_src}/AbstractOccupancyOcTree.cpp


### PR DESCRIPTION
Closes #29.

Switches the OctoMap C++ source from the vendored `src/octomap` git submodule to a CMake `FetchContent` fetch pinned to a release tag, so the source is no longer vendored and a version bump is a one-line `GIT_TAG` change. Builds on the scikit-build-core slice (#27).

## Summary
- `CMakeLists.txt`: fetch OctoMap via `FetchContent` instead of pointing at the submodule. Sources are populated only (not built through octomap's own CMake), then compiled straight into the extension as before, so the module stays self-contained (no octomap shared libraries at import time).
- Removed the `src/octomap` submodule and its `.gitmodules` entry (kept `github2pypi`), plus the now-vestigial `/src/` `.gitignore` rules that only existed to track it.

## Pinned to v1.8.0
`GIT_TAG` is pinned to **v1.8.0** to match the package version line: octomap-python `1.8.0.postN` bundles octomap `1.8.0`. The source list mirrors octomap's own CMakeLists for v1.8.0, including `dynamicEDTOctomap.cpp` (it has a real `.cpp` at v1.8.0; it only becomes header-only at v1.9.x).

## Note for review
- `GIT_TAG` pins a **release tag**, not a commit SHA, matching the issue's "one-line version bump" framing. Tags are mutable in principle; if you'd prefer SHA-pinned reproducibility, that's a one-line swap (and would mean dropping `GIT_SHALLOW`, which needs a ref).
- `FetchContent_MakeAvailable` is intentionally not used: octomap defines a CMake target named `octomap` that would collide with `python_add_library(octomap ...)`, and it would also build octovis/Qt. Hence the source-only `FetchContent_Populate` path (with the `CMP0169` guard for CMake 3.30+).

## Test plan
- [x] `pip install .` builds OctoMap v1.8.0 via FetchContent (clean build in a fresh venv)
- [x] `cd tests && pytest .` — 14/14 pass against the fetched version
- [x] `otool -L` on the built extension shows only `libc++`/`libSystem` — no octomap shared libraries, confirming static-linking behavior from the prior slice is preserved
- [x] `import octomap; octomap.OcTree(0.1)` works
