### PR TITLE
Run pytest from repo root and isolate temp output via tmp_path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,4 @@ jobs:
       run: uv run black --check .
 
     - name: Test
-      run: |
-        cd tests
-        uv run pytest .
+      run: uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ Homepage = "https://github.com/wkentaro/octomap-python"
 [dependency-groups]
 dev = ["black", "flake8", "pytest"]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.scikit-build]
 cmake.version = ">=3.18"
 # No pure-Python package directory; CMake installs the compiled extension

--- a/tests/octomap_test.py
+++ b/tests/octomap_test.py
@@ -1,313 +1,300 @@
 import os
 import tempfile
-import unittest
 
 import numpy as np
+import pytest
 
 import octomap
 
 
-class OctreeTestCase(unittest.TestCase):
-    def setUp(self):
-        self.tree = octomap.OcTree(0.1)
+@pytest.fixture
+def tree() -> octomap.OcTree:
+    return octomap.OcTree(0.1)
 
-    def tearDown(self):
-        pass
 
-    def test_readBinary(self):
-        self.assertTrue(self.tree.readBinary(b"test.bt"))
-        self.assertFalse(self.tree.readBinary(b"test0.bt"))
+def test_readBinary(tree: octomap.OcTree) -> None:
+    assert tree.readBinary(b"test.bt")
+    assert not tree.readBinary(b"test0.bt")
 
-    def test_writeBinary(self):
-        self.assertTrue(self.tree.writeBinary(b"test1.bt"))
 
-    def test_str_paths(self):
-        self.tree.updateNode(np.array([1.0, 2.0, 3.0]), True)
-        self.tree.updateInnerOccupancy()
-        with tempfile.TemporaryDirectory() as tmp:
-            bt_path = os.path.join(tmp, "tree.bt")
-            ot_path = os.path.join(tmp, "tree.ot")
+def test_writeBinary(tree: octomap.OcTree) -> None:
+    assert tree.writeBinary(b"test1.bt")
 
-            # writeBinary / readBinary round-trip with str paths
-            self.assertTrue(self.tree.writeBinary(bt_path))
-            expected_bt = self.tree.writeBinary()
-            tree_bin = octomap.OcTree(0.1)
-            self.assertTrue(tree_bin.readBinary(bt_path))
-            self.assertEqual(tree_bin.writeBinary(), expected_bt)
 
-            # the str constructor reads a .bt file without TypeError
-            tree_ctor = octomap.OcTree(bt_path)
-            self.assertEqual(tree_ctor.writeBinary(), expected_bt)
+def test_str_paths(tree: octomap.OcTree) -> None:
+    tree.updateNode(np.array([1.0, 2.0, 3.0]), True)
+    tree.updateInnerOccupancy()
+    with tempfile.TemporaryDirectory() as tmp:
+        bt_path = os.path.join(tmp, "tree.bt")
+        ot_path = os.path.join(tmp, "tree.ot")
 
-            # write / read round-trip with str paths
-            self.assertTrue(self.tree.write(ot_path))
-            expected_ot = self.tree.write()
-            tree_full = octomap.OcTree.read(ot_path)
-            self.assertEqual(tree_full.write(), expected_ot)
+        # writeBinary / readBinary round-trip with str paths
+        assert tree.writeBinary(bt_path)
+        expected_bt = tree.writeBinary()
+        tree_bin = octomap.OcTree(0.1)
+        assert tree_bin.readBinary(bt_path)
+        assert tree_bin.writeBinary() == expected_bt
 
-    def test_checkTree(self):
-        self.tree.readBinary(b"test.bt")
-        data = self.tree.write()
-        tree2 = octomap.OcTree.read(data)
-        self.assertEqual(tree2.write(), data)
+        # the str constructor reads a .bt file without TypeError
+        tree_ctor = octomap.OcTree(bt_path)
+        assert tree_ctor.writeBinary() == expected_bt
 
-    def test_checkBinary(self):
-        self.tree.readBinary(b"test.bt")
-        data = self.tree.writeBinary()
-        tree2 = octomap.OcTree(0.1)
-        tree2.readBinary(data)
-        self.assertEqual(tree2.writeBinary(), data)
+        # write / read round-trip with str paths
+        assert tree.write(ot_path)
+        expected_ot = tree.write()
+        tree_full = octomap.OcTree.read(ot_path)
+        assert tree_full.write() == expected_ot
 
-    def test_BBXMax(self):
-        a = np.array((1.0, 2.0, 3.0))
-        self.tree.setBBXMax(a)
-        self.assertTrue(np.allclose(self.tree.getBBXMax(), a))
 
-    def test_BBXMin(self):
-        a = np.array((1.0, 2.0, 3.0))
-        self.tree.setBBXMin(a)
-        self.assertTrue(np.allclose(self.tree.getBBXMin(), a))
+def test_checkTree(tree: octomap.OcTree) -> None:
+    tree.readBinary(b"test.bt")
+    data = tree.write()
+    tree2 = octomap.OcTree.read(data)
+    assert tree2.write() == data
 
-    def test_Resolution(self):
-        r = 1.0
-        self.tree.setResolution(r)
-        self.assertAlmostEqual(self.tree.getResolution(), r)
 
-    def test_Node(self):
-        self.tree.insertPointCloud(
-            np.array([[1.0, 0.0, 0.0]]), np.array([0.0, 0.0, 0.0])
+def test_checkBinary(tree: octomap.OcTree) -> None:
+    tree.readBinary(b"test.bt")
+    data = tree.writeBinary()
+    tree2 = octomap.OcTree(0.1)
+    tree2.readBinary(data)
+    assert tree2.writeBinary() == data
+
+
+def test_BBXMax(tree: octomap.OcTree) -> None:
+    a = np.array((1.0, 2.0, 3.0))
+    tree.setBBXMax(a)
+    assert np.allclose(tree.getBBXMax(), a)
+
+
+def test_BBXMin(tree: octomap.OcTree) -> None:
+    a = np.array((1.0, 2.0, 3.0))
+    tree.setBBXMin(a)
+    assert np.allclose(tree.getBBXMin(), a)
+
+
+def test_Resolution(tree: octomap.OcTree) -> None:
+    r = 1.0
+    tree.setResolution(r)
+    assert tree.getResolution() == pytest.approx(r)
+
+
+def test_Node(tree: octomap.OcTree) -> None:
+    tree.insertPointCloud(
+        np.array([[1.0, 0.0, 0.0]]), np.array([0.0, 0.0, 0.0])
+    )
+    node = tree.getRoot()
+    assert node.getValue() == pytest.approx(0.847298, abs=1e-5)
+    assert node.childExists(0) is False
+    assert node.childExists(1) is False
+    assert node.childExists(2) is False
+    assert node.childExists(3) is False
+    assert node.childExists(4) is False
+    assert node.childExists(5) is False
+    assert node.childExists(6) is False
+    assert node.childExists(7) is True
+    assert tree.getNodeChild(node, 7).getValue() == pytest.approx(
+        0.847298, abs=1e-5
+    )
+
+
+def test_Update(tree: octomap.OcTree) -> None:
+    test_point1 = np.array([1.0, 2.0, 3.0])
+    test_point2 = np.array([0.0, 0.0, 0.0])
+    test_point3 = np.array([5.0, 5.0, 5.0])
+    tree.insertPointCloud(np.array([test_point1]), np.array([0.0, 0.0, 0.0]))
+    node1 = tree.search(test_point1)
+    node2 = tree.search(test_point2)
+    node3 = tree.search(test_point3)
+    assert tree.isNodeOccupied(node1)
+    assert not tree.isNodeOccupied(node2)
+    with pytest.raises(octomap.NullPointerException):
+        tree.isNodeOccupied(node3)
+
+    tree.updateNode(test_point2, True)
+    tree.updateInnerOccupancy()
+    assert tree.isNodeOccupied(node2)
+
+
+def test_Iterator(tree: octomap.OcTree) -> None:
+    tree.insertPointCloud(
+        np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [-1.0, 0.0, 0.0],
+                [0.0, 0.0, -1.0],
+            ]
+        ),
+        np.array([0.0, 1.0, 0.0]),
+    )
+    nodes = [i for i in tree.begin_tree() if i.isLeaf()]
+    leafs = [i for i in tree.begin_leafs()]
+    leafs_bbx = [
+        i
+        for i in tree.begin_leafs_bbx(
+            np.array([0.0, 0.0, 0.0]), np.array([1.0, 0.0, 0.0])
         )
-        node = self.tree.getRoot()
-        self.assertAlmostEqual(node.getValue(), 0.847298, places=5)
-        self.assertEqual(node.childExists(0), False)
-        self.assertEqual(node.childExists(1), False)
-        self.assertEqual(node.childExists(2), False)
-        self.assertEqual(node.childExists(3), False)
-        self.assertEqual(node.childExists(4), False)
-        self.assertEqual(node.childExists(5), False)
-        self.assertEqual(node.childExists(6), False)
-        self.assertEqual(node.childExists(7), True)
-        self.assertAlmostEqual(
-            self.tree.getNodeChild(node, 7).getValue(), 0.847298, places=5
-        )
-
-    def test_Update(self):
-        test_point1 = np.array([1.0, 2.0, 3.0])
-        test_point2 = np.array([0.0, 0.0, 0.0])
-        test_point3 = np.array([5.0, 5.0, 5.0])
-        self.tree.insertPointCloud(
-            np.array([test_point1]), np.array([0.0, 0.0, 0.0])
-        )
-        node1 = self.tree.search(test_point1)
-        node2 = self.tree.search(test_point2)
-        node3 = self.tree.search(test_point3)
-        self.assertTrue(self.tree.isNodeOccupied(node1))
-        self.assertFalse(self.tree.isNodeOccupied(node2))
-        self.assertRaises(
-            octomap.NullPointerException,
-            lambda: self.tree.isNodeOccupied(node3),
-        )
-
-        self.tree.updateNode(test_point2, True)
-        self.tree.updateInnerOccupancy()
-        self.assertTrue(self.tree.isNodeOccupied(node2))
-
-    def test_Iterator(self):
-        self.tree.insertPointCloud(
-            np.array(
-                [
-                    [1.0, 0.0, 0.0],
-                    [0.0, 0.0, 1.0],
-                    [-1.0, 0.0, 0.0],
-                    [0.0, 0.0, -1.0],
-                ]
-            ),
-            np.array([0.0, 1.0, 0.0]),
-        )
-        nodes = [i for i in self.tree.begin_tree() if i.isLeaf()]
-        leafs = [i for i in self.tree.begin_leafs()]
-        leafs_bbx = [
-            i
-            for i in self.tree.begin_leafs_bbx(
-                np.array([0.0, 0.0, 0.0]), np.array([1.0, 0.0, 0.0])
-            )
-        ]
-        self.assertEqual(len(nodes), len(leafs))
-        self.assertEqual(len(leafs_bbx), 2)
-
-    def test_castRay(self):
-        origin = np.array([0.0, 0.0, 0.0])
-        direction = np.array([1.0, 0.0, 0.0])
-        end = np.array([0.0, 0.0, 0.0])
-
-        # miss still reports where the ray stopped: the voxel entered when
-        # the ray reached maxRange=5.0 along x, with y/z at the origin voxel
-        # center (0.05 = half of the 0.1 resolution)
-        hit = self.tree.castRay(
-            origin=origin,
-            direction=direction,
-            end=end,
-            ignoreUnknownCells=True,
-            maxRange=5.0,
-        )
-        self.assertFalse(hit)
-        self.assertTrue(np.allclose(end, [5.05, 0.05, 0.05]))
-
-        self.tree.insertPointCloud(
-            np.array(
-                [
-                    [1.0, 0.0, 0.0],
-                    [0.0, 0.0, 1.0],
-                    [-1.0, 0.0, 0.0],
-                    [0.0, 0.0, -1.0],
-                ]
-            ),
-            np.array([0.0, 0.0, 0.0]),
-        )
-
-        # hit
-        end[:] = [9.0, 9.0, 9.0]
-        hit = self.tree.castRay(
-            origin=origin,
-            direction=direction,
-            end=end,
-            ignoreUnknownCells=True,
-        )
-        self.assertTrue(hit)
-        self.assertTrue(np.allclose(end, [1.05, 0.05, 0.05]))
-
-        # a ray that cannot be cast (origin outside the tree) leaves end
-        # unchanged rather than overwriting it
-        end[:] = [7.0, 7.0, 7.0]
-        hit = self.tree.castRay(
-            origin=np.array([1e6, 1e6, 1e6]),
-            direction=direction,
-            end=end,
-            ignoreUnknownCells=True,
-            maxRange=5.0,
-        )
-        self.assertFalse(hit)
-        self.assertTrue(np.allclose(end, [7.0, 7.0, 7.0]))
-
-    def test_updateNodes(self):
-        # test points
-        test_point1 = np.array([1.0, 2.0, 3.0])
-        test_point2 = np.array([0.0, 0.0, 0.0])
-        test_point3 = np.array([5.0, 5.0, 5.0])
-
-        # *not* present
-        node1 = self.tree.search(test_point1)
-        node2 = self.tree.search(test_point2)
-        node3 = self.tree.search(test_point3)
-        self.assertRaises(
-            octomap.NullPointerException,
-            lambda: self.tree.isNodeOccupied(node1),
-        )
-        self.assertRaises(
-            octomap.NullPointerException,
-            lambda: self.tree.isNodeOccupied(node2),
-        )
-        self.assertRaises(
-            octomap.NullPointerException,
-            lambda: self.tree.isNodeOccupied(node3),
-        )
-
-        # batch update w/ test points
-        self.tree.updateNodes([test_point1, test_point2, test_point3], True)
-
-        # occupied
-        node1 = self.tree.search(test_point1)
-        node2 = self.tree.search(test_point2)
-        node3 = self.tree.search(test_point3)
-        self.assertTrue(self.tree.isNodeOccupied(node1))
-        self.assertTrue(self.tree.isNodeOccupied(node2))
-        self.assertTrue(self.tree.isNodeOccupied(node3))
-
-    def test_insertDiscretizedPointCloud(self):
-        test_point1 = np.array([1.0, 2.0, 3.0])
-        test_point2 = np.array([0.0, 0.0, 0.0])
-        test_point3 = np.array([5.0, 5.0, 5.0])
-
-        self.tree.insertPointCloud(
-            np.array([test_point1]), np.array([0.0, 0.0, 0.0]), discretize=True
-        )
-
-        node1 = self.tree.search(test_point1)
-        node2 = self.tree.search(test_point2)
-        node3 = self.tree.search(test_point3)
-
-        self.assertTrue(self.tree.isNodeOccupied(node1))
-        self.assertFalse(self.tree.isNodeOccupied(node2))
-        self.assertRaises(
-            octomap.NullPointerException,
-            lambda: self.tree.isNodeOccupied(node3),
-        )
-
-    def test_dynamicEDT(self):
-        # A single occupied voxel at the origin: the Euclidean distance
-        # transform should read ~0 at the obstacle and grow linearly with
-        # distance away from it.
-        self.tree.updateNode(np.array([0.0, 0.0, 0.0]), True)
-        self.tree.updateInnerOccupancy()
-        self.tree.dynamicEDT_generate(
-            maxdist=4.0,
-            bbx_min=np.array([-2.0, -2.0, -2.0]),
-            bbx_max=np.array([2.0, 2.0, 2.0]),
-            treatUnknownAsOccupied=False,
-        )
-        self.tree.dynamicEDT_update(True)
-
-        res = self.tree.getResolution()
-        self.assertAlmostEqual(
-            self.tree.dynamicEDT_getDistance(np.array([0.0, 0.0, 0.0])),
-            0.0,
-            delta=res,
-        )
-        self.assertAlmostEqual(
-            self.tree.dynamicEDT_getDistance(np.array([1.0, 0.0, 0.0])),
-            1.0,
-            delta=res,
-        )
-        self.assertGreaterEqual(self.tree.dynamicEDT_getMaxDist(), 4.0)
-
-        # the only obstacle is the voxel at the origin, so the closest
-        # obstacle to any query point is ~[0, 0, 0], and the returned
-        # distance matches dynamicEDT_getDistance for the same query
-        query = np.array([1.0, 0.0, 0.0])
-        distance, obstacle = (
-            self.tree.dynamicEDT_getDistanceAndClosestObstacle(query)
-        )
-        self.assertEqual(distance, self.tree.dynamicEDT_getDistance(query))
-        self.assertTrue(np.allclose(obstacle, [0.0, 0.0, 0.0], atol=res))
-
-        # a query outside the distance map reports -1.0 and no obstacle
-        distance, obstacle = (
-            self.tree.dynamicEDT_getDistanceAndClosestObstacle(
-                np.array([10.0, 10.0, 10.0])
-            )
-        )
-        self.assertEqual(distance, -1.0)
-        self.assertIsNone(obstacle)
-
-        # a query inside the map but beyond maxdist has its distance capped
-        # at the maximum and no recorded obstacle (fresh tree to keep this
-        # tree's distance field intact)
-        far_tree = octomap.OcTree(0.1)
-        far_tree.updateNode(np.array([0.0, 0.0, 0.0]), True)
-        far_tree.updateInnerOccupancy()
-        far_tree.dynamicEDT_generate(
-            maxdist=1.0,
-            bbx_min=np.array([-3.0, -3.0, -3.0]),
-            bbx_max=np.array([3.0, 3.0, 3.0]),
-            treatUnknownAsOccupied=False,
-        )
-        far_tree.dynamicEDT_update(True)
-        distance, obstacle = far_tree.dynamicEDT_getDistanceAndClosestObstacle(
-            np.array([2.0, 0.0, 0.0])
-        )
-        self.assertEqual(distance, far_tree.dynamicEDT_getMaxDist())
-        self.assertIsNone(obstacle)
+    ]
+    assert len(nodes) == len(leafs)
+    assert len(leafs_bbx) == 2
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_castRay(tree: octomap.OcTree) -> None:
+    origin = np.array([0.0, 0.0, 0.0])
+    direction = np.array([1.0, 0.0, 0.0])
+    end = np.array([0.0, 0.0, 0.0])
+
+    # miss still reports where the ray stopped: the voxel entered when
+    # the ray reached maxRange=5.0 along x, with y/z at the origin voxel
+    # center (0.05 = half of the 0.1 resolution)
+    hit = tree.castRay(
+        origin=origin,
+        direction=direction,
+        end=end,
+        ignoreUnknownCells=True,
+        maxRange=5.0,
+    )
+    assert not hit
+    assert np.allclose(end, [5.05, 0.05, 0.05])
+
+    tree.insertPointCloud(
+        np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [-1.0, 0.0, 0.0],
+                [0.0, 0.0, -1.0],
+            ]
+        ),
+        np.array([0.0, 0.0, 0.0]),
+    )
+
+    # hit
+    end[:] = [9.0, 9.0, 9.0]
+    hit = tree.castRay(
+        origin=origin,
+        direction=direction,
+        end=end,
+        ignoreUnknownCells=True,
+    )
+    assert hit
+    assert np.allclose(end, [1.05, 0.05, 0.05])
+
+    # a ray that cannot be cast (origin outside the tree) leaves end
+    # unchanged rather than overwriting it
+    end[:] = [7.0, 7.0, 7.0]
+    hit = tree.castRay(
+        origin=np.array([1e6, 1e6, 1e6]),
+        direction=direction,
+        end=end,
+        ignoreUnknownCells=True,
+        maxRange=5.0,
+    )
+    assert not hit
+    assert np.allclose(end, [7.0, 7.0, 7.0])
+
+
+def test_updateNodes(tree: octomap.OcTree) -> None:
+    test_point1 = np.array([1.0, 2.0, 3.0])
+    test_point2 = np.array([0.0, 0.0, 0.0])
+    test_point3 = np.array([5.0, 5.0, 5.0])
+
+    # *not* present
+    node1 = tree.search(test_point1)
+    node2 = tree.search(test_point2)
+    node3 = tree.search(test_point3)
+    with pytest.raises(octomap.NullPointerException):
+        tree.isNodeOccupied(node1)
+    with pytest.raises(octomap.NullPointerException):
+        tree.isNodeOccupied(node2)
+    with pytest.raises(octomap.NullPointerException):
+        tree.isNodeOccupied(node3)
+
+    # batch update w/ test points
+    tree.updateNodes([test_point1, test_point2, test_point3], True)
+
+    # occupied
+    node1 = tree.search(test_point1)
+    node2 = tree.search(test_point2)
+    node3 = tree.search(test_point3)
+    assert tree.isNodeOccupied(node1)
+    assert tree.isNodeOccupied(node2)
+    assert tree.isNodeOccupied(node3)
+
+
+def test_insertDiscretizedPointCloud(tree: octomap.OcTree) -> None:
+    test_point1 = np.array([1.0, 2.0, 3.0])
+    test_point2 = np.array([0.0, 0.0, 0.0])
+    test_point3 = np.array([5.0, 5.0, 5.0])
+
+    tree.insertPointCloud(
+        np.array([test_point1]), np.array([0.0, 0.0, 0.0]), discretize=True
+    )
+
+    node1 = tree.search(test_point1)
+    node2 = tree.search(test_point2)
+    node3 = tree.search(test_point3)
+
+    assert tree.isNodeOccupied(node1)
+    assert not tree.isNodeOccupied(node2)
+    with pytest.raises(octomap.NullPointerException):
+        tree.isNodeOccupied(node3)
+
+
+def test_dynamicEDT(tree: octomap.OcTree) -> None:
+    # A single occupied voxel at the origin: the Euclidean distance transform
+    # should read ~0 at the obstacle and grow linearly with distance away from
+    # it.
+    tree.updateNode(np.array([0.0, 0.0, 0.0]), True)
+    tree.updateInnerOccupancy()
+    tree.dynamicEDT_generate(
+        maxdist=4.0,
+        bbx_min=np.array([-2.0, -2.0, -2.0]),
+        bbx_max=np.array([2.0, 2.0, 2.0]),
+        treatUnknownAsOccupied=False,
+    )
+    tree.dynamicEDT_update(True)
+
+    res = tree.getResolution()
+    assert tree.dynamicEDT_getDistance(
+        np.array([0.0, 0.0, 0.0])
+    ) == pytest.approx(0.0, abs=res)
+    assert tree.dynamicEDT_getDistance(
+        np.array([1.0, 0.0, 0.0])
+    ) == pytest.approx(1.0, abs=res)
+    assert tree.dynamicEDT_getMaxDist() >= 4.0
+
+    # the only obstacle is the voxel at the origin, so the closest obstacle to
+    # any query point is ~[0, 0, 0], and the returned distance matches
+    # dynamicEDT_getDistance for the same query
+    query = np.array([1.0, 0.0, 0.0])
+    distance, obstacle = tree.dynamicEDT_getDistanceAndClosestObstacle(query)
+    assert distance == tree.dynamicEDT_getDistance(query)
+    assert np.allclose(obstacle, [0.0, 0.0, 0.0], atol=res)
+
+    # a query outside the distance map reports -1.0 and no obstacle
+    distance, obstacle = tree.dynamicEDT_getDistanceAndClosestObstacle(
+        np.array([10.0, 10.0, 10.0])
+    )
+    assert distance == -1.0
+    assert obstacle is None
+
+    # a query inside the map but beyond maxdist has its distance capped at the
+    # maximum and no recorded obstacle (fresh tree to keep this tree's distance
+    # field intact)
+    far_tree = octomap.OcTree(0.1)
+    far_tree.updateNode(np.array([0.0, 0.0, 0.0]), True)
+    far_tree.updateInnerOccupancy()
+    far_tree.dynamicEDT_generate(
+        maxdist=1.0,
+        bbx_min=np.array([-3.0, -3.0, -3.0]),
+        bbx_max=np.array([3.0, 3.0, 3.0]),
+        treatUnknownAsOccupied=False,
+    )
+    far_tree.dynamicEDT_update(True)
+    distance, obstacle = far_tree.dynamicEDT_getDistanceAndClosestObstacle(
+        np.array([2.0, 0.0, 0.0])
+    )
+    assert distance == far_tree.dynamicEDT_getMaxDist()
+    assert obstacle is None

--- a/tests/octomap_test.py
+++ b/tests/octomap_test.py
@@ -1,10 +1,11 @@
-import os
-import tempfile
+import pathlib
 
 import numpy as np
 import pytest
 
 import octomap
+
+TEST_BT = str(pathlib.Path(__file__).parent / "test.bt").encode()
 
 
 @pytest.fixture
@@ -13,48 +14,47 @@ def tree() -> octomap.OcTree:
 
 
 def test_readBinary(tree: octomap.OcTree) -> None:
-    assert tree.readBinary(b"test.bt")
+    assert tree.readBinary(TEST_BT)
     assert not tree.readBinary(b"test0.bt")
 
 
-def test_writeBinary(tree: octomap.OcTree) -> None:
-    assert tree.writeBinary(b"test1.bt")
+def test_writeBinary(tree: octomap.OcTree, tmp_path: pathlib.Path) -> None:
+    assert tree.writeBinary(str(tmp_path / "test1.bt").encode())
 
 
-def test_str_paths(tree: octomap.OcTree) -> None:
+def test_str_paths(tree: octomap.OcTree, tmp_path: pathlib.Path) -> None:
     tree.updateNode(np.array([1.0, 2.0, 3.0]), True)
     tree.updateInnerOccupancy()
-    with tempfile.TemporaryDirectory() as tmp:
-        bt_path = os.path.join(tmp, "tree.bt")
-        ot_path = os.path.join(tmp, "tree.ot")
+    bt_path = str(tmp_path / "tree.bt")
+    ot_path = str(tmp_path / "tree.ot")
 
-        # writeBinary / readBinary round-trip with str paths
-        assert tree.writeBinary(bt_path)
-        expected_bt = tree.writeBinary()
-        tree_bin = octomap.OcTree(0.1)
-        assert tree_bin.readBinary(bt_path)
-        assert tree_bin.writeBinary() == expected_bt
+    # writeBinary / readBinary round-trip with str paths
+    assert tree.writeBinary(bt_path)
+    expected_bt = tree.writeBinary()
+    tree_bin = octomap.OcTree(0.1)
+    assert tree_bin.readBinary(bt_path)
+    assert tree_bin.writeBinary() == expected_bt
 
-        # the str constructor reads a .bt file without TypeError
-        tree_ctor = octomap.OcTree(bt_path)
-        assert tree_ctor.writeBinary() == expected_bt
+    # the str constructor reads a .bt file without TypeError
+    tree_ctor = octomap.OcTree(bt_path)
+    assert tree_ctor.writeBinary() == expected_bt
 
-        # write / read round-trip with str paths
-        assert tree.write(ot_path)
-        expected_ot = tree.write()
-        tree_full = octomap.OcTree.read(ot_path)
-        assert tree_full.write() == expected_ot
+    # write / read round-trip with str paths
+    assert tree.write(ot_path)
+    expected_ot = tree.write()
+    tree_full = octomap.OcTree.read(ot_path)
+    assert tree_full.write() == expected_ot
 
 
 def test_checkTree(tree: octomap.OcTree) -> None:
-    tree.readBinary(b"test.bt")
+    tree.readBinary(TEST_BT)
     data = tree.write()
     tree2 = octomap.OcTree.read(data)
     assert tree2.write() == data
 
 
 def test_checkBinary(tree: octomap.OcTree) -> None:
-    tree.readBinary(b"test.bt")
+    tree.readBinary(TEST_BT)
     data = tree.writeBinary()
     tree2 = octomap.OcTree(0.1)
     tree2.readBinary(data)


### PR DESCRIPTION
## Summary
- Run the test suite from the repo root: resolve `test.bt` relative to `__file__` and add `testpaths = ["tests"]`, so `uv run pytest` no longer needs `cd tests`.
- Write `test1.bt` into pytest's `tmp_path` instead of the cwd, so the suite leaves no stray file behind.
- Convert the `unittest.TestCase` to plain `pytest` functions with a `tree` fixture.
- Drop the `cd tests` step from CI.

## Test plan
- [x] `uv run pytest` (from repo root) — 14 passed
- [x] `uv run flake8 .` and `uv run black --check .`
- [x] Confirmed no stray `test1.bt` left in `tests/` after a run
