### PR TITLE
chore: retire github2pypi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "github2pypi"]
-	path = github2pypi
-	url = https://github.com/wkentaro/github2pypi.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,11 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "cython", "numpy"]
+requires = ["scikit-build-core>=0.10", "cython", "numpy", "hatch-fancy-pypi-readme"]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "octomap-python"
 version = "1.8.0.post12"
 description = "Python binding of the OctoMap library."
-readme = "README.md"
 license = { text = "BSD-3-Clause" }
 maintainers = [
     { name = "Kentaro Wada", email = "www.kentaro.wada@gmail.com" },
@@ -22,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
+dynamic = ["readme"]
 
 [project.optional-dependencies]
 # The examples use an old GUI stack pinned to keep it working: glooey 0.3.6
@@ -50,6 +50,22 @@ cmake.version = ">=3.18"
 # No pure-Python package directory; CMake installs the compiled extension
 # module straight to the wheel root.
 wheel.packages = []
+metadata.readme.provider = "scikit_build_core.metadata.fancy_pypi_readme"
+
+# github2pypi used to rewrite README's relative URLs to absolute ones so the
+# PyPI long description renders images; fancy-pypi-readme does that at build
+# time, keeping README.md's relative links intact for GitHub.
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+fragments = [{ path = "README.md" }]
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = 'src="(?!https?://)([^"]+)"'
+replacement = 'src="https://raw.githubusercontent.com/wkentaro/octomap-python/main/\1"'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+pattern = '!\[([^\]]*)\]\((?!https?://)([^)]+)\)'
+replacement = '![\1](https://raw.githubusercontent.com/wkentaro/octomap-python/main/\2)'
 
 [tool.black]
 line-length = 79
@@ -57,6 +73,5 @@ exclude = '''
 (
     ^/\..*
   | ^/src/
-  | ^/github2pypi/
 )
 '''


### PR DESCRIPTION
Closes #30.

Retires the `github2pypi` submodule. github2pypi was used to rewrite the README's relative URLs to absolute ones so the PyPI long description renders images; this replaces that mechanism so README.md keeps its relative links for GitHub while PyPI still renders.

## Summary
- Remove the `github2pypi` submodule and its (now sole) `.gitmodules` entry, and drop the orphaned `github2pypi` line from the `[tool.black]` exclude.
- Make the project `readme` dynamic via scikit-build-core's `fancy-pypi-readme` metadata provider, which rewrites relative `src="..."` / `![...](...)` URLs to `raw.githubusercontent.com/.../main/...` at build time. README.md itself is unchanged.

## Scope
Strictly github2pypi retirement. The octomap binding work (castRay, `os.fsencode` paths, `dynamicEDT_getDistanceAndClosestObstacle`) and README badge refresh that were previously bundled here have been dropped; the binding work lives on its own branch.

## Test plan
- [x] No `github2pypi` references remain except the explanatory comment (`git grep`)
- [x] `pyproject.toml` is valid TOML
- [x] `fancy-pypi-readme` provider rewrites the relative screenshot URL to an absolute `raw.githubusercontent.com` URL and leaves absolute badge URLs untouched (verified end-to-end through `scikit_build_core.metadata.fancy_pypi_readme`)