### PR TITLE
chore: move examples deps from a published extra to a dependency-group

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ uv add octomap-python
 
 ```bash
 git clone --recursive https://github.com/wkentaro/octomap-python.git && cd octomap-python
-uv sync --extra example
+uv sync --group examples
 
 cd examples
 uv run python insertPointCloud.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,24 +23,22 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 
-[project.optional-dependencies]
-# The examples use an old GUI stack pinned to keep it working: glooey 0.3.6
-# needs pyglet 1.x APIs (e.g. graphics.OrderedGroup), trimesh.viewer.SceneWidget
-# was removed in trimesh 4.8.3, and glooey's autoprop/typeguard chain relies on
-# ast.Str (removed in Python 3.12), so the examples run on Python <=3.11; see
-# .python-version.
-example = [
-    "glooey==0.3.6",
-    "imgviz>=1.2.0",
-    "pyglet<2",
-    "trimesh[easy]<4.8.3",
-]
-
 [project.urls]
 Homepage = "https://github.com/wkentaro/octomap-python"
 
 [dependency-groups]
 dev = ["black", "flake8", "pytest"]
+# The examples use an old GUI stack pinned to keep it working: glooey 0.3.6
+# needs pyglet 1.x APIs (e.g. graphics.OrderedGroup), trimesh.viewer.SceneWidget
+# was removed in trimesh 4.8.3, and glooey's autoprop/typeguard chain relies on
+# ast.Str (removed in Python 3.12), so the examples run on Python <=3.11; see
+# .python-version.
+examples = [
+    "glooey==0.3.6",
+    "imgviz>=1.2.0",
+    "pyglet<2",
+    "trimesh[easy]<4.8.3",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/uv.lock
+++ b/uv.lock
@@ -1484,15 +1484,6 @@ dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
-[package.optional-dependencies]
-example = [
-    { name = "glooey" },
-    { name = "imgviz", version = "1.7.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "imgviz", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyglet" },
-    { name = "trimesh", extra = ["easy"] },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "black", version = "25.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -1501,22 +1492,28 @@ dev = [
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
+examples = [
+    { name = "glooey" },
+    { name = "imgviz", version = "1.7.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "imgviz", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyglet" },
+    { name = "trimesh", extra = ["easy"] },
+]
 
 [package.metadata]
-requires-dist = [
-    { name = "glooey", marker = "extra == 'example'", specifier = "==0.3.6" },
-    { name = "imgviz", marker = "extra == 'example'", specifier = ">=1.2.0" },
-    { name = "numpy" },
-    { name = "pyglet", marker = "extra == 'example'", specifier = "<2" },
-    { name = "trimesh", extras = ["easy"], marker = "extra == 'example'", specifier = "<4.8.3" },
-]
-provides-extras = ["example"]
+requires-dist = [{ name = "numpy" }]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "black" },
     { name = "flake8" },
     { name = "pytest" },
+]
+examples = [
+    { name = "glooey", specifier = "==0.3.6" },
+    { name = "imgviz", specifier = ">=1.2.0" },
+    { name = "pyglet", specifier = "<2" },
+    { name = "trimesh", extras = ["easy"], specifier = "<4.8.3" },
 ]
 
 [[package]]


### PR DESCRIPTION
The examples deps were a published `[project.optional-dependencies]` extra, installable as `octomap-python[example]`. They are a contributor workflow for running `examples/`, not a feature of the installed library, and are pinned to an old GUI stack that only resolves on Python <=3.11 (glooey/pyglet/trimesh). Publishing that as a PyPI extra is a consumer-facing footgun.

This moves them to a `[dependency-groups]` `examples` group (PEP 735, not published), named to mirror the `examples/` directory. It is not synced by default, so the old GUI stack no longer enters every `uv sync` or CI, and the Python <=3.11 ceiling stays local to the group instead of capping the whole dev environment.

Behavior change: `pip install octomap-python[example]` no longer works for PyPI consumers (dependency-groups are not published). Given the pinned dead stack, that is the intended demotion. Run examples with `uv sync --group examples`.

## Test plan
- [x] `uv lock` resolves (89 packages, unchanged resolution)
- [x] `uv sync --group examples --locked` installs the Python <=3.11 pins (trimesh 4.8.2, pyglet 1.5.31)
- [x] plain `uv sync --locked` no longer installs the GUI stack
