### PR TITLE
ci: test lower and upper Python bounds (3.9, 3.14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.9', '3.14']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
CI tested only Python 3.9, so regressions on newer interpreters went unnoticed
until a user hit them. This pins the matrix to both ends of the supported range
declared by `requires-python = ">=3.9"`: 3.9 (lower bound) and 3.14 (latest
stable, the effective upper bound since there is no cap).

The examples group stays at <=3.11 via `.python-version` and is unaffected, as
CI does not exercise examples.

## Test plan
- [x] `uv sync --locked && uv run pytest` passes on 3.9
- [x] Extension builds and all 15 tests pass on 3.14 (numpy 2.4.6)
