### PR TITLE
ci: build binary wheels and sdist with cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,81 @@
+name: wheels
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build_wheels:
+    name: Wheels (${{ matrix.os }} ${{ matrix.archs }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            archs: x86_64
+          - os: ubuntu-24.04-arm
+            archs: aarch64
+          - os: macos-14
+            archs: arm64
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v4.1.0
+      env:
+        CIBW_ARCHS: ${{ matrix.archs }}
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: wheels-${{ matrix.os }}-${{ matrix.archs }}
+        path: wheelhouse/*.whl
+
+  build_sdist:
+    name: sdist
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build sdist
+      run: pipx run build --sdist
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: sdist
+        path: dist/*.tar.gz
+
+  # Windows ships no wheel; prove the sdist builds from source there.
+  test_sdist_windows:
+    name: sdist from source (windows)
+    needs: build_sdist
+    runs-on: windows-latest
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: sdist
+        path: dist
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - uses: actions/checkout@v4
+      with:
+        path: src
+
+    - name: Install from sdist
+      shell: bash
+      run: pip install --verbose dist/*.tar.gz
+
+    - name: Test
+      shell: bash
+      run: |
+        pip install pytest numpy
+        pytest src/tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,15 @@ replacement = 'src="https://raw.githubusercontent.com/wkentaro/octomap-python/ma
 pattern = '!\[([^\]]*)\]\((?!https?://)([^)]+)\)'
 replacement = '![\1](https://raw.githubusercontent.com/wkentaro/octomap-python/main/\2)'
 
+[tool.cibuildwheel]
+# Py 3.9-3.13; the trailing "t" free-threaded builds (cp313t-*) are excluded by
+# matching only cp3XX-* without the "t".
+build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
+# Only manylinux is shipped; musllinux (Alpine) users build from the sdist.
+skip = "*-musllinux*"
+test-requires = "pytest"
+test-command = "pytest {project}/tests"
+
 [tool.ruff]
 line-length = 79
 extend-exclude = ["src"]


### PR DESCRIPTION
## Summary
- Adds a `wheels` workflow that builds self-contained binary wheels with cibuildwheel: Linux **x86_64 + aarch64** (manylinux) and macOS **arm64**, across Python **3.9-3.13**.
- octomap/octomath/dynamicEDT3D are statically linked into the extension, so the auditwheel/delocate repair pass cibuildwheel runs by default finds no external octomap libs to bundle: the wheels are portable with no compiler or submodule needed at install time.
- The aarch64 leg runs on a native `ubuntu-24.04-arm` runner (no QEMU emulation), so it builds at native speed and its tests run like every other leg.
- cibuildwheel runs `pytest {project}/tests` against each installed wheel.
- An sdist is produced, and a `windows-latest` job installs it from source and runs the tests, covering the platforms that ship no wheel.

Closes #33.

## Notes
- **No macOS x86_64 (Intel) wheel.** GitHub's Intel `macos-13` runners are being retired and no longer schedule reliably, and the only remaining route (cross-compiling on the arm runner) cannot test the result. Shipping an untested binary would be worse than shipping none, since pip prefers a wheel over the sdist. Intel-mac users install from the sdist.
- **No musllinux (Alpine) wheel.** Only manylinux is shipped on Linux; musl/Alpine users build from the sdist. This keeps each Linux leg to one libc instead of doubling the build matrix.
- The matrix runs on `pull_request` too, so the wheel build is exercised on every PR.

## Test plan
- [x] `pyproject-build --sdist` produces an sdist that includes `tests/` + `tests/test.bt`
- [x] Installed the sdist from source into a clean venv (`--no-binary`, compiles octomap from FetchContent) and ran `pytest tests/` — 15 passed, with `import octomap` resolving to the installed module (run outside the source tree)
- [x] Full wheel builds run in CI across all three legs
