### PR TITLE
ci: publish to PyPI on release via Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    uses: ./.github/workflows/wheels.yml
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/octomap-python
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        path: dist
+        merge-multiple: true
+
+    - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,6 +8,7 @@ on:
       - 'v*'
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build_wheels:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ uv run python insertPointCloud.py
 <img src="examples/.readme/insertPointCloud.jpg" height="200px" />
 
 
+## Release
+
+Releases are published to PyPI by the `publish` workflow, which fires when a
+GitHub Release is published. It builds the wheel matrix + sdist and uploads via
+[PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC, no
+stored token).
+
+To cut a release:
+
+1. Bump `version` in `pyproject.toml` to match the new tag and commit it.
+2. Create a GitHub Release with tag `vX.Y.Z` (e.g. `v1.8.0.post13`).
+3. The `publish` workflow runs and uploads the built distributions to PyPI.
+
+
 ## Acknowledgement
 
 This is a fork of [neka-nat/python-octomap](https://github.com/neka-nat/python-octomap).


### PR DESCRIPTION
## Summary
- Add `publish.yml`, a dormant workflow that fires on a published GitHub Release and uploads to PyPI via [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC, no stored token secret).
- Reuse the existing `wheels.yml` to build the wheel matrix + sdist by exposing it via `workflow_call`; the publish job downloads those artifacts and ships them with `pypa/gh-action-pypi-publish`.
- Publish runs under the `pypi` environment with `id-token: write`, mirroring the `ihq` setup.
- Document the release steps in the README.

It does nothing on normal pushes/PRs and publishes nothing until a maintainer creates a Release. The PyPI trusted-publisher config and first-release go-ahead are already handled on the maintainer side.

## Test plan
- [x] `python -c "yaml.safe_load(...)"` parses both workflows
- [x] `actionlint` clean on `publish.yml` and `wheels.yml`

Closes #34
