### PR TITLE
chore: bump version to 1.8.0.post13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "octomap-python"
-version = "1.8.0.post12"
+version = "1.8.0.post13"
 description = "Python binding of the OctoMap library."
 license = { text = "BSD-3-Clause" }
 maintainers = [

--- a/uv.lock
+++ b/uv.lock
@@ -1317,7 +1317,7 @@ wheels = [
 
 [[package]]
 name = "octomap-python"
-version = "1.8.0.post12"
+version = "1.8.0.post13"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Bump the package version from `1.8.0.post12` to `1.8.0.post13` so the next GitHub Release publishes a new version to PyPI.

scikit-build-core reads the static `[project] version` field at build time (the git tag name does not set it), and PyPI rejects duplicate filename uploads. Without this bump, publishing a `v1.8.0.post13` release would rebuild `1.8.0.post12` artifacts and the publish job would fail on the collision.

`uv.lock` is updated in lockstep so `uv sync --locked` in CI stays green.

## Test plan
- [x] `uv sync --locked` resolves and builds cleanly
- [x] `uv run pytest` (15 passed)
- [x] `uv run ruff check .` and `ruff format --check .` clean
