### PR TITLE
chore: version the release as 1.8.0.13 instead of 1.8.0.post13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,16 @@
 
 All notable changes to this project are documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and the project uses [PEP 440](https://peps.python.org/pep-0440/) post-release
-versioning. The bundled OctoMap C++ library is pinned to v1.8.0.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions follow [PEP 440](https://peps.python.org/pep-0440/): the first three
+segments track the bundled OctoMap C++ library version (currently 1.8.0), and a
+fourth segment counts binding revisions on that upstream.
 
-This history was backfilled from git and PyPI release records. The `1.8.0.postN`
-series predates git tags, so each release is dated by its PyPI upload.
+This history was backfilled from git and PyPI release records. Releases through
+1.8.0.post12 used a `.postN` suffix and predate git tags, so each is dated by its
+PyPI upload.
 
-## [1.8.0.post13] - 2026-06-20
+## [1.8.0.13] - 2026-06-20
 
 The first release in over six years: a full build and tooling modernization plus
 several long-standing binding fixes.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(FetchContent)
 # OctoMap is fetched and pinned to a release tag rather than vendored as a git
 # submodule. Bumping the version is a one-line change to GIT_TAG.
 #
-# Pinned to v1.8.0 to match the package version line (octomap-python 1.8.0.postN
+# Pinned to v1.8.0 to match the package version line (octomap-python 1.8.0.N
 # bundles octomap 1.8.0).
 FetchContent_Declare(
   octomap

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ stored token).
 To cut a release:
 
 1. Bump `version` in `pyproject.toml` to match the new tag and commit it.
-2. Create a GitHub Release with tag `vX.Y.Z` (e.g. `v1.8.0.post13`).
+2. Create a GitHub Release with tag `vX.Y.Z` (e.g. `v1.8.0.13`).
 3. The `publish` workflow runs and uploads the built distributions to PyPI.
 
 ## Acknowledgement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "octomap-python"
-version = "1.8.0.post13"
+version = "1.8.0.13"
 description = "Python binding of the OctoMap library."
 license = { text = "BSD-3-Clause" }
 maintainers = [

--- a/uv.lock
+++ b/uv.lock
@@ -1317,7 +1317,7 @@ wheels = [
 
 [[package]]
 name = "octomap-python"
-version = "1.8.0.post13"
+version = "1.8.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Version the upcoming release as `1.8.0.13` instead of `1.8.0.post13`, before it is published.

`.postN` is the wrong PEP 440 segment for this release: post-releases are meant for changes that do not alter the software, but this one ships a new binding, bug fixes, and a build overhaul. Rather than decouple from the wrapped library (the version is deliberately aligned to OctoMap C++), this keeps the alignment and replaces the `.post` suffix with a fourth numeric segment, the same scheme `opencv-python` uses (`4.8.0.74` = OpenCV 4.8.0, build 74):

- First three segments track the bundled OctoMap version (`1.8.0`).
- Fourth segment counts binding revisions on that upstream (`.13`, `.14`, ...).
- A future OctoMap bump moves the base: OctoMap 1.9.0 -> `1.9.0`, then `1.9.0.1`. No `.post` going forward.

Ordering stays monotonic, so pip sees this as the latest and existing pins are unaffected: `1.8.0.post12` < `1.8.0.13` < `1.9.0` < `1.10.0`.

The CHANGELOG heading and its versioning note are updated to match.

## Test plan
- [x] `uv sync --locked` builds; `importlib.metadata.version("octomap-python")` reports `1.8.0.13`
- [x] Ordering verified with `packaging.version`: `1.8.0.post12 < 1.8.0.13 < 1.9.0 < 1.10.0`
- [x] `uv run pytest` (15 passed), `ruff check` / `ruff format --check` clean
