### PR TITLE
fix: point insertPointCloud.py camera marker toward the data

### DIFF
--- a/examples/insertPointCloud.py
+++ b/examples/insertPointCloud.py
@@ -53,6 +53,12 @@ def visualize(
         resolution=(width, height), focal=(K[0, 0], K[1, 1])
     )
     camera_marker = trimesh.creation.camera_marker(camera, marker_height=0.1)
+    # trimesh's camera_marker opens toward -Z (OpenGL convention) but the
+    # depth point cloud uses OpenCV (+Z forward). Rotate the marker 180 deg
+    # about X so the frustum opens toward the data instead of away from it.
+    opencv_from_opengl = tf.rotation_matrix(np.pi, [1, 0, 0])
+    for geometry in camera_marker:
+        geometry.apply_transform(opencv_from_opengl)
 
     # initial camera pose
     camera_transform = np.array(


### PR DESCRIPTION
The camera frustum marker in `examples/insertPointCloud.py` rendered pointing away from the scene instead of toward it.

Root cause is a camera-convention mismatch, not a trimesh regression: `trimesh.creation.camera_marker` builds the FOV toward `-Z` (the OpenGL convention, where a camera looks down its local `-Z`), but `pointcloud_from_depth` produces points in the OpenCV convention (`+Z` forward, since `z = depth`). The marker, drawn at the world origin, therefore opened opposite the data. The example never reconciled the two frames.

Fix: rotate the marker 180 deg about X (`R_x(pi)`), the standard OpenGL->OpenCV basis change, keeping `+X` to the right while flipping Y and Z so the frustum opens toward `+Z`.

## Test plan
- [x] Geometric check: frustum vertices' mean Z flips from `-0.08` to `+0.08`, matching the `+Z` point cloud
- [x] `ruff check` / `ruff format --check` clean
- [x] Confirmed visually in the GUI: frustum now opens into the scene in all three panels

Note: `examples/.readme/insertPointCloud.jpg` (shown in the README) still depicts the old frustum and should be regenerated from a fresh GUI screenshot in a follow-up.
