### PR TITLE
docs: list supported Python versions (3.9-3.13) as classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,11 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dynamic = ["readme"]


### PR DESCRIPTION
Per-version classifiers populate the version-filter sidebar on the PyPI project page; until now only the generic `Python :: 3` was advertised. The set mirrors the cibuildwheel `build` line (`cp39-*` … `cp313-*`), the source of truth for the tested matrix, so no untested version is claimed.

## Test plan
- [x] `python -c "import tomllib, pathlib; tomllib.loads(pathlib.Path('pyproject.toml').read_text())"` parses cleanly
