### PR TITLE
ci: build CPython 3.14 wheels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This history was backfilled from git and PyPI release records. Releases through
 1.8.0.post12 used a `.postN` suffix and predate git tags, so each is dated by its
 PyPI upload.
 
+## [Unreleased]
+
+### Added
+- Binary wheels for CPython 3.14.
+
 ## [1.8.0.13] - 2026-06-20
 
 The first release in over six years: a full build and tooling modernization plus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,9 @@ pattern = '!\[([^\]]*)\]\((?!https?://)([^)]+)\)'
 replacement = '![\1](https://raw.githubusercontent.com/wkentaro/octomap-python/main/\2)'
 
 [tool.cibuildwheel]
-# Py 3.9-3.13; the trailing "t" free-threaded builds (cp313t-*) are excluded by
-# matching only cp3XX-* without the "t".
-build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
+# Py 3.9-3.14; the trailing "t" free-threaded builds (e.g. cp314t-*) are excluded
+# by matching only cp3XX-* without the "t".
+build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
 # Only manylinux is shipped; musllinux (Alpine) users build from the sdist.
 skip = "*-musllinux*"
 test-requires = "pytest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dynamic = ["readme"]


### PR DESCRIPTION
Add `cp314-*` to the cibuildwheel build set so CPython 3.14 gets a binary wheel. Until now the matrix stopped at 3.13, so 3.14 users had to build from the sdist.

The extension already compiles and tests green on 3.14 (it's the upper bound in `ci.yml`), and the pinned `cibuildwheel@v4.1.0` recognizes the identifier, so this is just opting the version into the wheel build. Free-threaded `cp314t` stays excluded by the existing `cp3XX-*` (no trailing `t`) pattern.

## Test plan
- [x] `cibuildwheel==4.1.0 --print-build-identifiers` on the edited `pyproject.toml` lists `cp314-manylinux_x86_64` / `cp314-macosx_arm64`, and no `cp314t`
- [x] CI `wheels.yml` builds the cp314 wheels across linux x86_64/aarch64 + macOS arm64 (verifies on this PR)
