### PR TITLE
feat: bundle OctoMap C++ v1.10.0 (release 1.10.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,27 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow [PEP 440](https://peps.python.org/pep-0440/): the first three
-segments track the bundled OctoMap C++ library version (currently 1.8.0), and a
+segments track the bundled OctoMap C++ library version (currently 1.10.0), and a
 fourth segment counts binding revisions on that upstream.
 
 This history was backfilled from git and PyPI release records. Releases through
 1.8.0.post12 used a `.postN` suffix and predate git tags, so each is dated by its
 PyPI upload.
 
-## [Unreleased]
+## [1.10.0.0] - 2026-06-20
+
+Bumps the bundled OctoMap C++ library from 1.8.0 to 1.10.0, the current upstream
+release. No binding API changes.
 
 ### Added
 - Binary wheels for CPython 3.14.
+
+### Changed
+- Bundled OctoMap C++ library upgraded from 1.8.0 to 1.10.0, which carries
+  upstream's modern-compiler and C++17/20 build fixes.
+- `dynamicEDTOctomap.cpp` is no longer compiled: OctoMap made DynamicEDTOctomap a
+  header-only template (over the tree type) in 1.9.0, so it is now instantiated
+  through `octomap.pyx` instead.
 
 ## [1.8.0.13] - 2026-06-20
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,12 @@ include(FetchContent)
 # OctoMap is fetched and pinned to a release tag rather than vendored as a git
 # submodule. Bumping the version is a one-line change to GIT_TAG.
 #
-# Pinned to v1.8.0 to match the package version line (octomap-python 1.8.0.N
-# bundles octomap 1.8.0).
+# Pinned to v1.10.0 to match the package version line (octomap-python 1.10.0.N
+# bundles octomap 1.10.0).
 FetchContent_Declare(
   octomap
   GIT_REPOSITORY https://github.com/OctoMap/octomap.git
-  GIT_TAG v1.8.0
+  GIT_TAG v1.10.0
   GIT_SHALLOW TRUE
 )
 # Populate the sources only; octomap's own CMake build is intentionally not run.
@@ -45,7 +45,9 @@ set(edt_src "${octomap_dir}/dynamicEDT3D/src")
 # OctoMap, octomath and dynamicEDT3D are compiled straight into the extension
 # so the module is self-contained: no octomap shared libraries to resolve at
 # import time. octovis/Qt are simply never referenced here. The source lists
-# mirror octomap's own CMakeLists for the pinned release.
+# mirror octomap's own CMakeLists for the pinned release. DynamicEDTOctomap is
+# header-only since octomap v1.9.0 (templated over the tree type), so only
+# dynamicEDT3D.cpp is compiled; the template is instantiated via octomap.pyx.
 set(octomap_sources
   ${octomap_src}/AbstractOcTree.cpp
   ${octomap_src}/AbstractOccupancyOcTree.cpp
@@ -60,7 +62,6 @@ set(octomap_sources
   ${octomap_src}/math/Quaternion.cpp
   ${octomap_src}/math/Pose6D.cpp
   ${edt_src}/dynamicEDT3D.cpp
-  ${edt_src}/dynamicEDTOctomap.cpp
 )
 
 add_custom_command(

--- a/octomap/octomap.pyx
+++ b/octomap/octomap.pyx
@@ -108,7 +108,7 @@ cdef class iterator_base:
     Iterator over the complete tree (inner nodes and leafs).
     """
     cdef defs.OcTree *treeptr
-    cdef defs.OccupancyOcTreeBase[defs.OcTreeNode].iterator_base *thisptr
+    cdef defs.iterator_base *thisptr
     def __cinit__(self):
         pass
 

--- a/octomap/octomap_defs.pxd
+++ b/octomap/octomap_defs.pxd
@@ -62,20 +62,24 @@ cdef extern from "octomap/OcTreeKey.h" namespace "octomap":
         unsigned short int& operator[](unsigned int i)
 
 cdef extern from "include_and_setting.h" namespace "octomap":
-    cdef cppclass OccupancyOcTreeBase[T]:
-        cppclass iterator_base:
-            point3d getCoordinate()
-            unsigned int getDepth()
-            OcTreeKey getIndexKey()
-            OcTreeKey& getKey()
-            double getSize() except +
-            double getX() except +
-            double getY() except +
-            double getZ() except +
-            OcTreeNode& operator*()
-            bool operator==(iterator_base &other)
-            bool operator!=(iterator_base &other)
+    # OcTree's iterators became templated over the node type in OctoMap 1.9.0, so
+    # iterator_base is bound to its concrete instantiation by C++ name and
+    # declared at module scope; the concrete iterators below still inherit it.
+    cdef cppclass iterator_base "octomap::OcTree::iterator_base<octomap::OcTreeNode>":
+        point3d getCoordinate()
+        unsigned int getDepth()
+        OcTreeKey getIndexKey()
+        OcTreeKey& getKey()
+        double getSize() except +
+        double getX() except +
+        double getY() except +
+        double getZ() except +
+        OcTreeNode& operator*()
+        bool operator==(iterator_base &other)
+        bool operator!=(iterator_base &other)
 
+cdef extern from "include_and_setting.h" namespace "octomap":
+    cdef cppclass OccupancyOcTreeBase[T]:
         cppclass tree_iterator(iterator_base):
             tree_iterator() except +
             tree_iterator(tree_iterator&) except +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "octomap-python"
-version = "1.8.0.13"
+version = "1.10.0.0"
 description = "Python binding of the OctoMap library."
 license = { text = "BSD-3-Clause" }
 maintainers = [

--- a/uv.lock
+++ b/uv.lock
@@ -1317,7 +1317,7 @@ wheels = [
 
 [[package]]
 name = "octomap-python"
-version = "1.8.0.13"
+version = "1.10.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- Bumps the bundled OctoMap C++ library from v1.8.0 to v1.10.0 (current upstream) and releases octomap-python `1.10.0.0`. No binding API changes.
- Drops `dynamicEDTOctomap.cpp` from the compiled sources: OctoMap made `DynamicEDTOctomap` a header-only template (over the tree type) in v1.9.0, so it is now instantiated through `octomap.pyx`. Keeping the stale source line would fail the build.
- Binds the Cython `iterator_base` to its concrete instantiation `octomap::OcTree::iterator_base<octomap::OcTreeNode>`: v1.10.0 turned the iterator base into a class template, so the previous bare `iterator_base` no longer compiled.

## Test plan
- [x] `uv sync --reinstall-package octomap-python` builds the extension against octomap v1.10.0
- [x] `uv run pytest` — 15 passed
- [x] Runtime smoke test of all three iterators (`begin_tree`/`begin_leafs`/`begin_leafs_bbx`, incl. `isLeaf`) and the dynamicEDT path
- [x] `uv run ruff check .` and `ruff format --check .`
