### PR TITLE
fix: return an OcTreeKey instance from adjustKeyAtDepth

### DIFF
--- a/octomap/octomap.pyx
+++ b/octomap/octomap.pyx
@@ -337,7 +337,7 @@ cdef class OcTree:
         key_in[1] = key[1]
         key_in[2] = key[2]
         cdef defs.OcTreeKey key_out = self.thisptr.adjustKeyAtDepth(key_in, <int?>depth)
-        res = OcTreeKey
+        res = OcTreeKey()
         res[0] = key_out[0]
         res[1] = key_out[1]
         res[2] = key_out[2]

--- a/tests/octomap_test.py
+++ b/tests/octomap_test.py
@@ -79,6 +79,20 @@ def test_Resolution(tree: octomap.OcTree) -> None:
     assert tree.getResolution() == pytest.approx(r)
 
 
+def test_adjustKeyAtDepth(tree: octomap.OcTree) -> None:
+    key = tree.coordToKey(np.array([1.0, 2.0, 3.0]))
+
+    # adjusting to the full tree depth leaves the key unchanged
+    assert tree.adjustKeyAtDepth(key, tree.getTreeDepth()) == key
+
+    # at a coarser depth the key snaps to that depth's voxel and is stable
+    # under a second adjustment
+    coarse_depth = tree.getTreeDepth() - 2
+    coarse = tree.adjustKeyAtDepth(key, coarse_depth)
+    assert isinstance(coarse, octomap.OcTreeKey)
+    assert tree.adjustKeyAtDepth(coarse, coarse_depth) == coarse
+
+
 def test_Node(tree: octomap.OcTree) -> None:
     tree.insertPointCloud(
         np.array([[1.0, 0.0, 0.0]]), np.array([0.0, 0.0, 0.0])


### PR DESCRIPTION
`adjustKeyAtDepth` bound its result name to the `OcTreeKey` class instead of
an instance (`res = OcTreeKey`), so the subsequent `res[0] = ...` assignments
hit a type object and the method always raised
`TypeError: 'type' object does not support item assignment` — it never returned
a key. The one-character fix calls `OcTreeKey()`, matching the idiom every
sibling method (`coordToKey`, `coordToKeyChecked`, `keyToCoord`) already uses.

## Test plan
- [x] new `test_adjustKeyAtDepth` covers the full-depth identity and coarser-depth idempotence (would raise `TypeError` on the old code)
- [x] `uv run pytest -q` — 16 passed
- [x] `uv run ruff check .`
