### PR TITLE
feat: ship Windows AMD64 binary wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,6 +24,8 @@ jobs:
             archs: aarch64
           - os: macos-14
             archs: arm64
+          - os: windows-latest
+            archs: AMD64
 
     steps:
     - uses: actions/checkout@v4
@@ -52,7 +54,8 @@ jobs:
         name: sdist
         path: dist/*.tar.gz
 
-  # Windows ships no wheel; prove the sdist builds from source there.
+  # Windows ships an AMD64 wheel (see build_wheels); this guards the remaining
+  # from-source path there (e.g. win_arm64, or pip falling back to the sdist).
   test_sdist_windows:
     name: sdist from source (windows)
     needs: build_sdist


### PR DESCRIPTION
Adds a `windows-latest` / `AMD64` runner to the cibuildwheel matrix in `wheels.yml` so `pip install octomap-python` pulls a prebuilt wheel on Windows instead of requiring MSVC build tools.

The existing `build = "cp39-* … cp314-*"` pattern already matches `*-win_amd64`, so only the runner was needed. The OctoMap FetchContent sources already compile under MSVC (the `sdist from source (windows)` job has been green), so the wheel build reuses that path and runs the test suite via cibuildwheel's `test-command`. That sdist job stays as a guard for the remaining from-source cases (win_arm64, sdist fallback); its now-stale "ships no wheel" comment is updated.

Closes #62.

## Test plan
- [x] This PR's `wheels.yml` run produces `octomap_python-*-cp3XX-win_amd64.whl` (real verification, since MSVC/cibuildwheel only runs in CI)
