### PR TITLE
fix: raise instead of segfaulting when OcTree/ColorOcTree.read() gets a bad path

### DIFF
--- a/octomap/octomap.pyx
+++ b/octomap/octomap.pyx
@@ -589,6 +589,13 @@ cdef class OccupancyOcTreeBase:
         self.thisptr.getMetricMax(x, y, z)
         return np.array([x, y, z], dtype=float)
 
+def _raise_read_error(serialized, filename, type_name):
+    if serialized:
+        raise ValueError(f"failed to deserialize {type_name} from the given bytes")
+    path = os.fsdecode(filename)
+    os.stat(path)  # raises FileNotFoundError if the path is missing
+    raise OSError(f"failed to read {type_name} from {path!r}")
+
 def _octree_read(filename):
     """
     Deserialize an OcTree from a file path or from its serialized bytes.
@@ -599,12 +606,15 @@ def _octree_read(filename):
     # still alive, then free the placeholder we are replacing
     cdef defs.OcTree* placeholder = <defs.OcTree*>tree.thisptr
     filename = os.fsencode(filename)
-    if filename.startswith(b"# Octomap OcTree file"):
+    serialized = filename.startswith(b"# Octomap OcTree file")
+    if serialized:
         iss.str(string(<char*?>filename, len(filename)))
         tree.thisptr = <defs.OcTree*>placeholder.read(<defs.istream&?>iss)
     else:
         tree.thisptr = <defs.OcTree*>placeholder.read(string(<char*?>filename))
     del placeholder
+    if tree.thisptr == NULL:
+        _raise_read_error(serialized=serialized, filename=filename, type_name="OcTree")
     return tree
 
 cdef class OcTree(OccupancyOcTreeBase):
@@ -1036,12 +1046,15 @@ def _color_octree_read(filename):
     # still alive, then free the placeholder we are replacing
     cdef defs.ColorOcTree* placeholder = <defs.ColorOcTree*>tree.thisptr
     filename = os.fsencode(filename)
-    if filename.startswith(b"# Octomap OcTree file"):
+    serialized = filename.startswith(b"# Octomap OcTree file")
+    if serialized:
         iss.str(string(<char*?>filename, len(filename)))
         tree.thisptr = <defs.ColorOcTree*>placeholder.read(<defs.istream&?>iss)
     else:
         tree.thisptr = <defs.ColorOcTree*>placeholder.read(string(<char*?>filename))
     del placeholder
+    if tree.thisptr == NULL:
+        _raise_read_error(serialized=serialized, filename=filename, type_name="ColorOcTree")
     return tree
 
 cdef class ColorOcTree(OccupancyOcTreeBase):

--- a/tests/color_octree_test.py
+++ b/tests/color_octree_test.py
@@ -200,6 +200,18 @@ def test_write_read_preserves_color(
     assert loaded.search(point).getColor() == (10, 20, 30)
 
 
+def test_read_missing_path_raises(tmp_path: pathlib.Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        octomap.ColorOcTree.read(tmp_path / "nonexistent.ot")
+
+
+def test_read_unreadable_file_raises(tmp_path: pathlib.Path) -> None:
+    corrupt = tmp_path / "corrupt.ot"
+    corrupt.write_bytes(b"not an octree")
+    with pytest.raises(OSError, match="failed to read"):
+        octomap.ColorOcTree.read(corrupt)
+
+
 def test_write_read_pathlib(
     tree: octomap.ColorOcTree, tmp_path: pathlib.Path
 ) -> None:

--- a/tests/octomap_test.py
+++ b/tests/octomap_test.py
@@ -70,6 +70,18 @@ def test_path_objects(tree: octomap.OcTree, tmp_path: pathlib.Path) -> None:
     assert tree_full.write() == expected_ot
 
 
+def test_read_missing_path_raises(tmp_path: pathlib.Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        octomap.OcTree.read(tmp_path / "nonexistent.ot")
+
+
+def test_read_unreadable_file_raises(tmp_path: pathlib.Path) -> None:
+    corrupt = tmp_path / "corrupt.ot"
+    corrupt.write_bytes(b"not an octree")
+    with pytest.raises(OSError, match="failed to read"):
+        octomap.OcTree.read(corrupt)
+
+
 def test_checkTree(tree: octomap.OcTree) -> None:
     tree.readBinary(TEST_BT)
     data = tree.write()


### PR DESCRIPTION
`OcTree.read()` / `ColorOcTree.read()` segfaulted instead of raising when handed a missing or unreadable path (#68). octomap's C++ `AbstractOcTree::read()` returns `NULL` in that case; the wrappers assigned it straight to `thisptr`, so the next method call dereferenced `NULL` and took down the interpreter with SIGSEGV.

Now the wrappers NULL-check after `read()` and raise a Python exception: `FileNotFoundError` for a missing path, `OSError` for an unreadable/corrupt file, and `ValueError` for bad serialized bytes. Both `OcTree` and `ColorOcTree` go through one shared helper.

## Test plan
- [x] `octomap.OcTree.read("/nonexistent.ot").getTreeType()` now raises `FileNotFoundError` (exit 0) instead of exit 139
- [x] regression tests added: `test_read_missing_path_raises` and `test_read_unreadable_file_raises` in `tests/octomap_test.py` and `tests/color_octree_test.py`
- [x] `uv run pytest tests/` — 40 passed
- [x] `uv run ruff check` on the touched tests — clean

Closes #68
