### PR TITLE
docs: prepare 1.10.0.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ This history was backfilled from git and PyPI release records. Releases through
 1.8.0.post12 used a `.postN` suffix and predate git tags, so each is dated by its
 PyPI upload.
 
-## [Unreleased]
+## [1.10.0.0] - 2026-06-20
+
+Bumps the bundled OctoMap C++ library from 1.8.0 to 1.10.0 and adds
+`ColorOcTree`/`ColorOcTreeNode` bindings, Windows AMD64 wheels, and a shipped
+type stub, alongside several binding fixes. Drops Python 3.9, which reached end
+of life; the minimum is now Python 3.10.
 
 ### Added
 - `ColorOcTree` and `ColorOcTreeNode` bindings, exposing a per-voxel RGB color
@@ -20,29 +25,29 @@ PyPI upload.
   occupancy, search, iterator, and IO surface. Color is serialized by the full
   map format (`write` / `read`, `.ot`); the binary format (`.bt`) stores
   occupancy only.
+- Binary wheels for CPython 3.14.
+- Binary wheels for Windows AMD64.
+- A shipped `octomap.pyi` type stub for the compiled extension, enabling static
+  type checkers and editor completion.
 
 ### Changed
 - The occupancy/search/IO surface shared by every tree now lives on a common
   `OccupancyOcTreeBase`, which both `OcTree` and `ColorOcTree` extend. `OcTree`'s
   public API is unchanged.
-
-### Removed
-- Python 3.9 support, which reached end of life; the minimum is now Python 3.10.
-
-## [1.10.0.0] - 2026-06-20
-
-Bumps the bundled OctoMap C++ library from 1.8.0 to 1.10.0, the current upstream
-release. No binding API changes.
-
-### Added
-- Binary wheels for CPython 3.14.
-
-### Changed
 - Bundled OctoMap C++ library upgraded from 1.8.0 to 1.10.0, which carries
   upstream's modern-compiler and C++17/20 build fixes.
 - `dynamicEDTOctomap.cpp` is no longer compiled: OctoMap made DynamicEDTOctomap a
   header-only template (over the tree type) in 1.9.0, so it is now instantiated
   through `octomap.pyx` instead.
+- Build pinned to Cython 3 and NumPy 2.
+
+### Fixed
+- `OcTree.read()` and `ColorOcTree.read()` now raise instead of segfaulting when
+  given a path that does not resolve to a valid OctoMap file.
+- `adjustKeyAtDepth` now returns an `OcTreeKey` instance.
+
+### Removed
+- Python 3.9 support, which reached end of life; the minimum is now Python 3.10.
 
 ## [1.8.0.13] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Or with [uv](https://docs.astral.sh/uv/):
 uv add octomap-python
 ```
 
-Binary wheels are published for Linux (x86_64, aarch64) and macOS (Apple
-Silicon), CPython 3.10-3.14. Windows and other platforms build from the sdist
-and need a C++ compiler.
+Binary wheels are published for Linux (x86_64, aarch64), macOS (Apple Silicon),
+and Windows (AMD64), CPython 3.10-3.14. Other platforms build from the sdist and
+need a C++ compiler.
 
 ## Quick start
 


### PR DESCRIPTION
Pre-release cleanup for `v1.10.0.0`, surfaced by a final audit of the release.
The version bump was committed before ColorOcTree and the rest of the post-bump
work landed, so the release metadata had drifted from what the tag will actually
ship:

- **CHANGELOG**: the dated `[1.10.0.0]` section still claimed "No binding API
  changes" while ColorOcTree/ColorOcTreeNode, Windows AMD64 wheels, the shipped
  `.pyi` stub, the Cython 3 / NumPy 2 pin, the `read()` segfault fix, the
  `adjustKeyAtDepth` fix, and the breaking Python 3.9 drop sat in `[Unreleased]`
  or were undocumented. Folded them all into `[1.10.0.0]` and dropped the false
  summary.
- **README**: a Windows AMD64 wheel is now built and published, so the install
  section no longer tells Windows users to build from the sdist.

Docs only; no code or build changes.

## Test plan
- [x] Changelog entry cross-checked against `git log v1.8.0.13..HEAD` so every user-visible change is recorded
- [x] README wheel claim matches the `wheels.yml` build matrix (Linux x86_64/aarch64, macOS arm64, Windows AMD64)
